### PR TITLE
feat: separate the Basmala from each Surah's first verse (+ getVerseCountByPage fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.0
+* **New**: `getBasmala(surahNumber)` returns the Basmala prefixed to a Surah's first verse, or `null` for Surah 1 (its Basmala is verse 1 itself) and Surah 9 (no Basmala). Unlike the `basmala` constant, it matches the script used by the verse text.
+* **New**: `getVerse()` and `getVersesTextByPage()` accept `includeBasmala` (defaults to `true`), allowing the Basmala to be separated from a Surah's first verse and rendered as a heading.
+* **API**: Defaults preserve existing behavior - no code changes required for users.
+
 ## 1.4.1
 * Analysis Issue fixes
 ## 1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * **New**: `getBasmala(surahNumber)` returns the Basmala prefixed to a Surah's first verse, or `null` for Surah 1 (its Basmala is verse 1 itself) and Surah 9 (no Basmala). Unlike the `basmala` constant, it matches the script used by the verse text.
 * **New**: `getVerse()` and `getVersesTextByPage()` accept `includeBasmala` (defaults to `true`), allowing the Basmala to be separated from a Surah's first verse and rendered as a heading.
 * **API**: Defaults preserve existing behavior - no code changes required for users.
+* **Fix**: `getVerseCountByPage()` summed each Surah's ending verse number instead of counting its verses, so it was only correct on pages where every Surah started at verse 1 (e.g. page 3 returned 16 instead of 11). Every page now counts correctly, and the 604 pages sum to `totalVerseCount`.
 
 ## 1.4.1
 * Analysis Issue fixes

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ To use this plugin, add `quran` as a [dependency in your pubspec.yaml file](http
 
 **_Verse:_**
 
--   **`getVerse(int surahNumber, int verseNumber, {bool verseEndSymbol})`** - Takes [surahNumber], [verseNumber] & [verseEndSymbol] (optional) and returns the Verse in Arabic
+-   **`getVerse(int surahNumber, int verseNumber, {bool verseEndSymbol, bool includeBasmala})`** - Takes [surahNumber], [verseNumber], [verseEndSymbol] (optional) & [includeBasmala] (optional) and returns the Verse in Arabic
+-   **`getBasmala(int surahNumber)`** - Takes [surahNumber] and returns the Basmala prefixed to that Surah's first verse, or `null` for Surah 1 (its Basmala is verse 1 itself) and Surah 9 (no Basmala)
 -   **`getVerseEndSymbol(int verseNumber, {bool arabicNumeral})`** - Takes [verseNumber], [arabicNumeral] (optional) and returns '۝' symbol with verse number
 -   **`isSajdahVerse(int surahNumber, int verseNumber)`** - Takes [surahNumber], [verseNumber] and returns true if verse is sajdah verse
 -   **`getVerseTranslation(int surahNumber, int verseNumber, {bool verseEndSymbol, Translation translation})`** - Takes [surahNumber], [verseNumber], [verseEndSymbol] (optional) & [translation] (optional) and returns verse translation
@@ -58,7 +59,7 @@ To use this plugin, add `quran` as a [dependency in your pubspec.yaml file](http
 -   **`getSurahCountByPage(int pageNumber)`** - Takes [pageNumber] and returns total surahs count in that page
 -   **`getSurahPages(int surahNumber)`** - Takes [surahNumber] and returns the list of page numbers of that surah
 -   **`getVerseCountByPage(int pageNumber)`** - Takes [pageNumber] and returns total verses count in that page
--   **`getVersesTextByPage(int pageNumber, {bool verseEndSymbol, SurahSeperator surahSeperator, customSurahSeperator})`** - Takes [pageNumber], [verseEndSymbol], [surahSeperator] & [customSurahSeperator] and returns the list of verses in that page
+-   **`getVersesTextByPage(int pageNumber, {bool verseEndSymbol, SurahSeperator surahSeperator, customSurahSeperator, bool includeBasmala})`** - Takes [pageNumber], [verseEndSymbol], [surahSeperator], [customSurahSeperator] & [includeBasmala] (optional) and returns the list of verses in that page
 
 **_URLs:_**
 

--- a/lib/quran.dart
+++ b/lib/quran.dart
@@ -62,7 +62,11 @@ const int totalSurahCount = 114;
 ///The constant total verse count
 const int totalVerseCount = 6236;
 
-///The constant 'بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ'
+///The constant Basmala, in the Uthmani script.
+///
+///Note: since v1.4.0 the verse text uses the simple (plain) tanzil script,
+///so this constant does not match the Basmala embedded in [getVerse] output.
+///Use [getBasmala] for a Basmala that matches the verse text.
 const String basmala = "بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ";
 
 ///The constant 'سَجْدَةٌ'
@@ -213,16 +217,46 @@ int getVerseCount(int surahNumber) {
   return int.parse(surah[surahNumber - 1]['aya'].toString());
 }
 
-///Takes [surahNumber], [verseNumber] & [verseEndSymbol] (optional) and returns the Verse in Arabic
+///Takes [surahNumber] and returns the Basmala that is prefixed to the first
+///verse of that Surah, or `null` if the Surah has no prefixed Basmala.
+///
+///Returns `null` for Surah 1 (Al-Fatihah), whose Basmala is verse 1 itself, and
+///for Surah 9 (At-Tawbah), which has no Basmala. The returned text is in the
+///same script as [getVerse] output, unlike the [basmala] constant.
+String? getBasmala(int surahNumber) {
+  if (surahNumber > 114 || surahNumber <= 0) {
+    throw "No Surah found with given surahNumber";
+  }
+
+  if (surahNumber == 1 || surahNumber == 9) return null;
+
+  //Surah 1 verse 1 is the Basmala itself, so it doubles as the canonical
+  //source of the Basmala in whichever script quranData currently uses.
+  return quranData[1]![1]!;
+}
+
+///Takes [surahNumber], [verseNumber], [verseEndSymbol] (optional) &
+///[includeBasmala] (optional) and returns the Verse in Arabic
+///
+///The first verse of every Surah except 1 and 9 has the Basmala prefixed to it.
+///Pass [includeBasmala] as `false` to get the verse without it, e.g. to render
+///the Basmala separately as a heading. See [getBasmala].
 String getVerse(
   int surahNumber,
   int verseNumber, {
   bool verseEndSymbol = false,
+  bool includeBasmala = true,
 }) {
-  final verse = quranData[surahNumber]?[verseNumber];
+  var verse = quranData[surahNumber]?[verseNumber];
 
   if (verse == null) {
     throw "No verse found with given surahNumber and verseNumber.\n\n";
+  }
+
+  final basmalaPrefix =
+      (includeBasmala || verseNumber != 1) ? null : getBasmala(surahNumber);
+  if (basmalaPrefix != null && verse.startsWith(basmalaPrefix)) {
+    verse = verse.substring(basmalaPrefix.length).trimLeft();
   }
 
   return verse + (verseEndSymbol ? getVerseEndSymbol(verseNumber) : "");
@@ -303,6 +337,7 @@ List<String> getVersesTextByPage(
   bool verseEndSymbol = false,
   SurahSeperator surahSeperator = SurahSeperator.none,
   String customSurahSeperator = "",
+  bool includeBasmala = true,
 }) {
   if (pageNumber > 604 || pageNumber <= 0) {
     throw "Invalid pageNumber";
@@ -327,7 +362,12 @@ List<String> getVersesTextByPage(
       verses.add(getSurahNameRussian(data["surah"]));
     }
     for (int j = data["start"]; j <= data["end"]; j++) {
-      verses.add(getVerse(data["surah"], j, verseEndSymbol: verseEndSymbol));
+      verses.add(getVerse(
+        data["surah"],
+        j,
+        verseEndSymbol: verseEndSymbol,
+        includeBasmala: includeBasmala,
+      ));
     }
   }
   return verses;

--- a/lib/quran.dart
+++ b/lib/quran.dart
@@ -87,9 +87,10 @@ int getVerseCountByPage(int pageNumber) {
   }
   int totalVerseCount = 0;
   for (int i = 0; i < pageData[pageNumber - 1].length; i++) {
-    totalVerseCount += int.parse(
-      pageData[pageNumber - 1][i]!["end"].toString(),
-    );
+    final surahOnPage = pageData[pageNumber - 1][i]!;
+    final start = int.parse(surahOnPage["start"].toString());
+    final end = int.parse(surahOnPage["end"].toString());
+    totalVerseCount += end - start + 1;
   }
   return totalVerseCount;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quran
 description: Quran text, translation, audio URLs, and details of pages, juz, surah, ayah, place of revelation etc.
-version: 1.4.1
+version: 1.5.0
 homepage: https://github.com/aqeelshamz/quran
 
 environment:

--- a/test/basmala_test.dart
+++ b/test/basmala_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quran/quran.dart' as quran;
+
+void main() {
+  group('getBasmala', () {
+    test('returns null for Surah 1, whose Basmala is verse 1 itself', () {
+      expect(quran.getBasmala(1), isNull);
+    });
+
+    test('returns null for Surah 9, which has no Basmala', () {
+      expect(quran.getBasmala(9), isNull);
+    });
+
+    test('matches the script used by the verse text', () {
+      expect(quran.getBasmala(2), quran.getVerse(1, 1));
+    });
+
+    test('throws on an invalid surahNumber', () {
+      expect(() => quran.getBasmala(0), throwsA(isA<String>()));
+      expect(() => quran.getBasmala(115), throwsA(isA<String>()));
+    });
+  });
+
+  group('getVerse includeBasmala', () {
+    test('defaults to including the Basmala', () {
+      expect(quran.getVerse(2, 1), startsWith(quran.getBasmala(2)!));
+      expect(quran.getVerse(2, 1), quran.getVerse(2, 1, includeBasmala: true));
+    });
+
+    test('strips the Basmala from verse 1 of every Surah that has one', () {
+      for (var surah = 1; surah <= 114; surah++) {
+        final basmala = quran.getBasmala(surah);
+        final stripped = quran.getVerse(surah, 1, includeBasmala: false);
+
+        expect(stripped, isNotEmpty, reason: 'surah $surah verse 1 is empty');
+        if (basmala != null) {
+          expect(stripped, isNot(startsWith(basmala)),
+              reason: 'surah $surah verse 1 kept its Basmala');
+          expect(quran.getVerse(surah, 1), '$basmala $stripped',
+              reason: 'surah $surah verse 1 lost more than its Basmala');
+        } else {
+          expect(stripped, quran.getVerse(surah, 1),
+              reason: 'surah $surah has no Basmala to strip');
+        }
+      }
+    });
+
+    test('leaves verses other than verse 1 untouched', () {
+      // Verse 27:30 quotes the Basmala mid-verse; it must survive.
+      expect(
+          quran.getVerse(27, 30, includeBasmala: false), quran.getVerse(27, 30));
+      expect(quran.getVerse(27, 30, includeBasmala: false),
+          contains(quran.getBasmala(27)!));
+    });
+
+    test('composes with verseEndSymbol', () {
+      expect(
+        quran.getVerse(2, 1, includeBasmala: false, verseEndSymbol: true),
+        quran.getVerse(2, 1, includeBasmala: false) +
+            quran.getVerseEndSymbol(1),
+      );
+    });
+  });
+
+  group('getVersesTextByPage', () {
+    test('passes includeBasmala through to the verses', () {
+      // Page 2 starts Surah 2 (Al-Baqarah) at verse 1.
+      final withBasmala = quran.getVersesTextByPage(2);
+      final without = quran.getVersesTextByPage(2, includeBasmala: false);
+
+      expect(withBasmala.first, startsWith(quran.getBasmala(2)!));
+      expect(without.first, isNot(startsWith(quran.getBasmala(2)!)));
+      expect(without.length, withBasmala.length);
+    });
+  });
+}

--- a/test/verse_count_by_page_test.dart
+++ b/test/verse_count_by_page_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quran/quran.dart' as quran;
+
+void main() {
+  group('getVerseCountByPage', () {
+    test('counts the verses on a page that does not start at verse 1', () {
+      // Page 3 holds Surah 2, verses 6-16.
+      expect(quran.getPageData(3), [
+        {"surah": 2, "start": 6, "end": 16}
+      ]);
+      expect(quran.getVerseCountByPage(3), 11);
+    });
+
+    test('counts the verses on a page that starts at verse 1', () {
+      expect(quran.getVerseCountByPage(1), 7); // Surah 1, verses 1-7
+    });
+
+    test('sums every page to the total verse count of the Quran', () {
+      var sum = 0;
+      for (var page = 1; page <= quran.totalPagesCount; page++) {
+        sum += quran.getVerseCountByPage(page);
+      }
+      expect(sum, quran.totalVerseCount);
+    });
+
+    test('counts across every Surah on a page with more than one', () {
+      final page = List.generate(quran.totalPagesCount, (i) => i + 1)
+          .firstWhere((p) => quran.getSurahCountByPage(p) > 1);
+      final expected = quran
+          .getPageData(page)
+          .fold<int>(0, (sum, e) => sum + (e["end"] as int) - (e["start"] as int) + 1);
+
+      expect(quran.getVerseCountByPage(page), expected);
+    });
+
+    test('throws on an invalid pageNumber', () {
+      expect(() => quran.getVerseCountByPage(0), throwsA(isA<String>()));
+      expect(() => quran.getVerseCountByPage(605), throwsA(isA<String>()));
+    });
+  });
+}


### PR DESCRIPTION
## Why

The verse text prefixes the Basmala to verse 1 of every Surah except 1 (where the Basmala *is* verse 1) and 9 (which has none). So `getVerse(2, 1)` returns:

> بِسْمِ اللَّهِ الرَّحْمَـٰنِ الرَّحِيمِ الم

There is currently no way to render the Basmala as a heading — the way a mushaf does — without it appearing twice.

Consumers can't strip it themselves either. Since v1.4.0 the verse text is in the simple (plain) tanzil script, while the exported `basmala` constant is still in the Uthmani script (`ٱ` vs `ا`). They are different strings, so `getVerse(2, 1).replaceFirst(basmala, '')` silently does nothing.

## What

- **`getBasmala(surahNumber)`** — returns the Basmala prefixed to that Surah's first verse, or `null` for Surahs 1 and 9. Unlike the `basmala` constant, it matches the script of the verse text.
- **`includeBasmala`** on `getVerse()` and `getVersesTextByPage()` — defaults to `true`, so **existing behavior is unchanged** and no caller needs to react.
- A doc note on the `basmala` constant pointing at the script difference. I deliberately did **not** change the constant's value: it's the correct Uthmani Basmala and changing it would break anyone rendering it today.
- **Fix `getVerseCountByPage()`** (second commit, happy to split into its own PR if you'd rather). It summed each Surah's *ending verse number* instead of counting its verses, so it was only correct on pages where every Surah starts at verse 1. Page 3 holds Al-Baqarah 6–16 and returned `16` instead of `11`.

## Notes on the implementation

The Basmala is derived from Surah 1 verse 1 — which is the Basmala itself — rather than hardcoded as a new constant. It can't drift out of sync with the text, and if the text source ever changes script again it follows automatically, which is exactly what broke the `basmala` constant in 1.4.0.

Stripping is scoped to `verseNumber == 1` and anchored with `startsWith`, so quotations of the Basmala inside other verses — 27:30 — are untouched.

## Tests

Added `test/` (the package had none). 14 tests, covering:

- round-trip over **all 114 Surahs**: `getVerse(s, 1) == '${getBasmala(s)} ${getVerse(s, 1, includeBasmala: false)}'`, so nothing more or less than the Basmala is removed
- Surah 1 and Surah 9 as the two exceptions; 27:30 preserved
- composition with `verseEndSymbol`; pass-through via `getVersesTextByPage`
- `getVerseCountByPage`: the 604 pages now sum to exactly `totalVerseCount` (6236)

`flutter test` green, `flutter analyze` clean.